### PR TITLE
[RFC] Multiple validation messages

### DIFF
--- a/src/Support/LanguageHelper.php
+++ b/src/Support/LanguageHelper.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tempest\Support;
 
-final class StringHelper
+final class LanguageHelper
 {
 
-    public static function naturalLangJoin(array $strings): string
+    public static function join(array $strings): string
     {
         $last = array_pop($strings);
 

--- a/src/Support/LanguageHelper.php
+++ b/src/Support/LanguageHelper.php
@@ -6,16 +6,19 @@ namespace Tempest\Support;
 
 final class LanguageHelper
 {
-
-    public static function join(array $strings): string
+    /**
+     * @param string[] $parts
+     *
+     * @return string
+     */
+    public static function join(array $parts): string
     {
-        $last = array_pop($strings);
+        $last = array_pop($parts);
 
-        if ($strings) {
-            return implode(', ', $strings) . ' ' . 'and' . ' ' . $last;
+        if ($parts) {
+            return implode(', ', $parts) . ' ' . 'and' . ' ' . $last;
         }
 
         return $last;
     }
-
 }

--- a/src/Support/StringHelper.php
+++ b/src/Support/StringHelper.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support;
+
+final class StringHelper
+{
+
+    public static function join(array $strings): string
+    {
+        $last = array_pop($strings);
+
+        if ($strings) {
+            return implode(', ', $strings) . ' ' . 'and' . ' ' . $last;
+        }
+
+        return $last;
+    }
+
+}

--- a/src/Support/StringHelper.php
+++ b/src/Support/StringHelper.php
@@ -7,7 +7,7 @@ namespace Tempest\Support;
 final class StringHelper
 {
 
-    public static function join(array $strings): string
+    public static function naturalLangJoin(array $strings): string
     {
         $last = array_pop($strings);
 

--- a/src/Validation/Exceptions/ValidationException.php
+++ b/src/Validation/Exceptions/ValidationException.php
@@ -22,7 +22,7 @@ final class ValidationException extends Exception
         foreach ($failingRules as $field => $failingRulesForField) {
             /** @var Rule $failingRuleForField */
             foreach ($failingRulesForField as $failingRuleForField) {
-                $messages[$field][] = "Value should " . StringHelper::join(ArrayHelper::wrap($failingRuleForField->message()));
+                $messages[$field][] = StringHelper::join(ArrayHelper::wrap($failingRuleForField->message()));
             }
         }
 

--- a/src/Validation/Exceptions/ValidationException.php
+++ b/src/Validation/Exceptions/ValidationException.php
@@ -7,7 +7,7 @@ namespace Tempest\Validation\Exceptions;
 use Exception;
 use Tempest\Validation\Rule;
 use Tempest\Support\ArrayHelper;
-use Tempest\Support\StringHelper;
+use Tempest\Support\LanguageHelper;
 
 final class ValidationException extends Exception
 {
@@ -22,7 +22,7 @@ final class ValidationException extends Exception
         foreach ($failingRules as $field => $failingRulesForField) {
             /** @var Rule $failingRuleForField */
             foreach ($failingRulesForField as $failingRuleForField) {
-                $messages[$field][] = StringHelper::naturalLangJoin(ArrayHelper::wrap($failingRuleForField->message()));
+                $messages[$field][] = LanguageHelper::join(ArrayHelper::wrap($failingRuleForField->message()));
             }
         }
 

--- a/src/Validation/Exceptions/ValidationException.php
+++ b/src/Validation/Exceptions/ValidationException.php
@@ -22,7 +22,7 @@ final class ValidationException extends Exception
         foreach ($failingRules as $field => $failingRulesForField) {
             /** @var Rule $failingRuleForField */
             foreach ($failingRulesForField as $failingRuleForField) {
-                $messages[$field][] = StringHelper::join(ArrayHelper::wrap($failingRuleForField->message()));
+                $messages[$field][] = StringHelper::naturalLangJoin(ArrayHelper::wrap($failingRuleForField->message()));
             }
         }
 

--- a/src/Validation/Exceptions/ValidationException.php
+++ b/src/Validation/Exceptions/ValidationException.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tempest\Validation\Exceptions;
 
 use Exception;
-use Tempest\Validation\Rule;
 use Tempest\Support\ArrayHelper;
 use Tempest\Support\LanguageHelper;
+use Tempest\Validation\Rule;
 
 final class ValidationException extends Exception
 {

--- a/src/Validation/Exceptions/ValidationException.php
+++ b/src/Validation/Exceptions/ValidationException.php
@@ -6,6 +6,8 @@ namespace Tempest\Validation\Exceptions;
 
 use Exception;
 use Tempest\Validation\Rule;
+use Tempest\Support\ArrayHelper;
+use Tempest\Support\StringHelper;
 
 final class ValidationException extends Exception
 {
@@ -20,7 +22,7 @@ final class ValidationException extends Exception
         foreach ($failingRules as $field => $failingRulesForField) {
             /** @var Rule $failingRuleForField */
             foreach ($failingRulesForField as $failingRuleForField) {
-                $messages[$field][] = $failingRuleForField->message();
+                $messages[$field][] = "Value should " . StringHelper::join(ArrayHelper::wrap($failingRuleForField->message()));
             }
         }
 

--- a/src/Validation/Rule.php
+++ b/src/Validation/Rule.php
@@ -8,5 +8,8 @@ interface Rule
 {
     public function isValid(mixed $value): bool;
 
-    public function message(): string;
+    /**
+     * @return string|string[]
+     */
+    public function message(): string|array;
 }

--- a/src/Validation/Rules/Password.php
+++ b/src/Validation/Rules/Password.php
@@ -6,6 +6,7 @@ namespace Tempest\Validation\Rules;
 
 use Attribute;
 use Tempest\Validation\Rule;
+use Tempest\Support\StringHelper;
 
 #[Attribute]
 final readonly class Password implements Rule
@@ -51,9 +52,9 @@ final readonly class Password implements Rule
         return true;
     }
 
-    public function message(): string
+    public function message(): array
     {
-        $messages = ["at least {$this->min} characters"];
+        $messages = ["contain at least {$this->min} characters"];
 
         if ($this->mixedCase) {
             $messages[] = 'at least one uppercase and one lowercase letter';
@@ -68,16 +69,6 @@ final readonly class Password implements Rule
             $messages[] = 'at least one symbol';
         }
 
-        return 'Value should contain ' . $this->natural_language_join($messages);
-    }
-
-    private function natural_language_join(array $list)
-    {
-        $last = array_pop($list);
-        if ($list) {
-            return implode(', ', $list) . ' ' . 'and' . ' ' . $last;
-        }
-
-        return $last;
+        return $messages;
     }
 }

--- a/src/Validation/Rules/Password.php
+++ b/src/Validation/Rules/Password.php
@@ -54,7 +54,7 @@ final readonly class Password implements Rule
 
     public function message(): array
     {
-        $messages = ["contain at least {$this->min} characters"];
+        $messages = ["Value should contain at least {$this->min} characters"];
 
         if ($this->mixedCase) {
             $messages[] = 'at least one uppercase and one lowercase letter';

--- a/src/Validation/Rules/Password.php
+++ b/src/Validation/Rules/Password.php
@@ -6,7 +6,7 @@ namespace Tempest\Validation\Rules;
 
 use Attribute;
 use Tempest\Validation\Rule;
-use Tempest\Support\StringHelper;
+use Tempest\Support\LanguageHelper;
 
 #[Attribute]
 final readonly class Password implements Rule

--- a/src/Validation/Rules/Password.php
+++ b/src/Validation/Rules/Password.php
@@ -6,7 +6,6 @@ namespace Tempest\Validation\Rules;
 
 use Attribute;
 use Tempest\Validation\Rule;
-use Tempest\Support\LanguageHelper;
 
 #[Attribute]
 final readonly class Password implements Rule
@@ -52,6 +51,9 @@ final readonly class Password implements Rule
         return true;
     }
 
+    /**
+     * @return string[]
+     */
     public function message(): array
     {
         $messages = ["Value should contain at least {$this->min} characters"];

--- a/tests/Unit/Validation/Rules/PasswordTest.php
+++ b/tests/Unit/Validation/Rules/PasswordTest.php
@@ -69,29 +69,29 @@ class PasswordTest extends TestCase
     public function test_message()
     {
         $rule = new Password();
-        $this->assertSame('contain at least 12 characters', $rule->message()[0]);
+        $this->assertSame('Value should contain at least 12 characters', $rule->message()[0]);
 
         $rule = new Password(min: 4);
-        $this->assertSame('contain at least 4 characters', $rule->message()[0]);
+        $this->assertSame('Value should contain at least 4 characters', $rule->message()[0]);
 
         $rule = new Password(mixedCase: true);
-        $this->assertSame('contain at least 12 characters', $rule->message()[0]);
+        $this->assertSame('Value should contain at least 12 characters', $rule->message()[0]);
         $this->assertSame('at least one uppercase and one lowercase letter', $rule->message()[1]);
 
         $rule = new Password(letters: true);
-        $this->assertSame('contain at least 12 characters', $rule->message()[0]);
+        $this->assertSame('Value should contain at least 12 characters', $rule->message()[0]);
         $this->assertSame('at least one letter', $rule->message()[1]);
 
         $rule = new Password(numbers: true);
-        $this->assertSame('contain at least 12 characters', $rule->message()[0]);
+        $this->assertSame('Value should contain at least 12 characters', $rule->message()[0]);
         $this->assertSame('at least one number', $rule->message()[1]);
 
         $rule = new Password(symbols: true);
-        $this->assertSame('contain at least 12 characters', $rule->message()[0]);
+        $this->assertSame('Value should contain at least 12 characters', $rule->message()[0]);
         $this->assertSame('at least one symbol', $rule->message()[1]);
 
         $rule = new Password(min: 4, mixedCase: true, letters: true, numbers: true, symbols: true);
-        $this->assertSame('contain at least 4 characters', $rule->message()[0]);
+        $this->assertSame('Value should contain at least 4 characters', $rule->message()[0]);
         $this->assertSame('at least one uppercase and one lowercase letter', $rule->message()[1]);
         $this->assertSame('at least one number', $rule->message()[2]);
         $this->assertSame('at least one letter', $rule->message()[3]);

--- a/tests/Unit/Validation/Rules/PasswordTest.php
+++ b/tests/Unit/Validation/Rules/PasswordTest.php
@@ -69,24 +69,32 @@ class PasswordTest extends TestCase
     public function test_message()
     {
         $rule = new Password();
-        $this->assertSame('Value should contain at least 12 characters', $rule->message());
+        $this->assertSame('contain at least 12 characters', $rule->message()[0]);
 
         $rule = new Password(min: 4);
-        $this->assertSame('Value should contain at least 4 characters', $rule->message());
+        $this->assertSame('contain at least 4 characters', $rule->message()[0]);
 
         $rule = new Password(mixedCase: true);
-        $this->assertSame('Value should contain at least 12 characters and at least one uppercase and one lowercase letter', $rule->message());
+        $this->assertSame('contain at least 12 characters', $rule->message()[0]);
+        $this->assertSame('at least one uppercase and one lowercase letter', $rule->message()[1]);
 
         $rule = new Password(letters: true);
-        $this->assertSame('Value should contain at least 12 characters and at least one letter', $rule->message());
+        $this->assertSame('contain at least 12 characters', $rule->message()[0]);
+        $this->assertSame('at least one letter', $rule->message()[1]);
 
         $rule = new Password(numbers: true);
-        $this->assertSame('Value should contain at least 12 characters and at least one number', $rule->message());
+        $this->assertSame('contain at least 12 characters', $rule->message()[0]);
+        $this->assertSame('at least one number', $rule->message()[1]);
 
         $rule = new Password(symbols: true);
-        $this->assertSame('Value should contain at least 12 characters and at least one symbol', $rule->message());
+        $this->assertSame('contain at least 12 characters', $rule->message()[0]);
+        $this->assertSame('at least one symbol', $rule->message()[1]);
 
         $rule = new Password(min: 4, mixedCase: true, letters: true, numbers: true, symbols: true);
-        $this->assertSame('Value should contain at least 4 characters, at least one uppercase and one lowercase letter, at least one number, at least one letter and at least one symbol', $rule->message());
+        $this->assertSame('contain at least 4 characters', $rule->message()[0]);
+        $this->assertSame('at least one uppercase and one lowercase letter', $rule->message()[1]);
+        $this->assertSame('at least one number', $rule->message()[2]);
+        $this->assertSame('at least one letter', $rule->message()[3]);
+        $this->assertSame('at least one symbol', $rule->message()[4]);
     }
 }

--- a/tests/Unit/Validation/ValidationExceptionTest.php
+++ b/tests/Unit/Validation/ValidationExceptionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Unit\Validation;
+
+use stdClass;
+use Tempest\Validation\Rule;
+use PHPUnit\Framework\TestCase;
+use Tempest\Validation\Exceptions\ValidationException;
+
+final class ValidationExceptionTest extends TestCase
+{
+
+    public function test_exception_message(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->expectExceptionMessage('Value should be a valid email address');
+
+        throw new ValidationException(new stdClass(), [
+            'email' => [
+                new class implements Rule {
+
+                    public function isValid(mixed $value): bool
+                    {
+                        return false;
+                    }
+
+                    public function message(): string|array
+                    {
+                        return 'Value should be a valid email address';
+                    }
+                }
+            ]
+        ]);
+    }
+
+    public function test_exception_message_with_multiple_messages(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->expectExceptionMessage('Value should be a valid email address');
+        $this->expectExceptionMessage("Value should praise tempest, old gods from the past and the new gods from the future");
+
+        throw new ValidationException(new stdClass(), [
+            'email' => [
+                new class implements Rule {
+
+                    public function isValid(mixed $value): bool
+                    {
+                        return false;
+                    }
+
+                    public function message(): string|array
+                    {
+                        return 'be a valid email address';
+                    }
+                },
+                new class implements Rule {
+
+                    public function isValid(mixed $value): bool
+                    {
+                        return false;
+                    }
+
+                    public function message(): string|array
+                    {
+                        return [
+                            'praise tempest',
+                            'old gods from the past',
+                            'the new gods from the future',
+                        ];
+                    }
+                }]
+        ]);
+    }
+
+}

--- a/tests/Unit/Validation/ValidationExceptionTest.php
+++ b/tests/Unit/Validation/ValidationExceptionTest.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Unit\Validation;
 
-use stdClass;
-use Tempest\Validation\Rule;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Tempest\Validation\Exceptions\ValidationException;
+use Tempest\Validation\Rule;
 
+/**
+ * @internal
+ * @small
+ */
 final class ValidationExceptionTest extends TestCase
 {
-
     public function test_exception_message(): void
     {
         $this->expectException(ValidationException::class);
@@ -20,8 +23,7 @@ final class ValidationExceptionTest extends TestCase
 
         throw new ValidationException(new stdClass(), [
             'email' => [
-                new class implements Rule {
-
+                new class () implements Rule {
                     public function isValid(mixed $value): bool
                     {
                         return false;
@@ -31,8 +33,8 @@ final class ValidationExceptionTest extends TestCase
                     {
                         return 'Value should be a valid email address';
                     }
-                }
-            ]
+                },
+            ],
         ]);
     }
 
@@ -45,8 +47,7 @@ final class ValidationExceptionTest extends TestCase
 
         throw new ValidationException(new stdClass(), [
             'email' => [
-                new class implements Rule {
-
+                new class () implements Rule {
                     public function isValid(mixed $value): bool
                     {
                         return false;
@@ -57,8 +58,7 @@ final class ValidationExceptionTest extends TestCase
                         return 'Value should be a valid email address';
                     }
                 },
-                new class implements Rule {
-
+                new class () implements Rule {
                     public function isValid(mixed $value): bool
                     {
                         return false;
@@ -72,8 +72,7 @@ final class ValidationExceptionTest extends TestCase
                             'the new gods from the future',
                         ];
                     }
-                }]
+                }],
         ]);
     }
-
 }

--- a/tests/Unit/Validation/ValidationExceptionTest.php
+++ b/tests/Unit/Validation/ValidationExceptionTest.php
@@ -54,7 +54,7 @@ final class ValidationExceptionTest extends TestCase
 
                     public function message(): string|array
                     {
-                        return 'be a valid email address';
+                        return 'Value should be a valid email address';
                     }
                 },
                 new class implements Rule {
@@ -67,7 +67,7 @@ final class ValidationExceptionTest extends TestCase
                     public function message(): string|array
                     {
                         return [
-                            'praise tempest',
+                            'Value should praise tempest',
                             'old gods from the past',
                             'the new gods from the future',
                         ];


### PR DESCRIPTION
Addresses: https://github.com/tempestphp/tempest-core/issues/8

This PR introduces changes to the return type for Rules - now they can return either a string or an array of strings.

When array is returned, messages will be joined using `naturalLangJoin` on a new class - StringHelper, alternatively, this could be a `join` method on `LangHelper` - lemme know which one do you prefer.

That method converts
```php
        $messages = [
            "Value should contain at least {$this->min} characters",
            "at least one number",
            'at least one uppercase and one lowercase letter'
        ];
```

to 

```
Value should contain at least 10 characters, at least one number and at least one uppercase and one lowercase letter.
```

When string is returned, the message won't be modified.

Some things to consider:
1. Now that the Rule can return either array of strings, or just string, we could either:
- rename the `message` method to `messages` and only allow arrays to be returned, then join them
- keep the `message` method as is (went this route because it's the least breaking change, I don't have a strong preference)

2. Most of rules start with `Value should` - maybe we can add that prefix in the exception itself? It'd be especially useful if we went the "messages + array" route, because adding that to the first element would be awkward